### PR TITLE
[DEV 2.15] Add `session_name` attribute to sessions table.

### DIFF
--- a/database.py
+++ b/database.py
@@ -22,6 +22,7 @@ def create_tables():
 
         CREATE TABLE IF NOT EXISTS sessions (
             session_id SERIAL PRIMARY KEY,
+            session_name VARCHAR(50) NOT NULL,
             user_id INT REFERENCES users(user_id) ON DELETE CASCADE,
             start_time TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
             end_time TIMESTAMP,

--- a/repositories/session_repo.py
+++ b/repositories/session_repo.py
@@ -7,19 +7,19 @@ router = APIRouter()
 @router.get("/sessions")
 def get_session():
     cur = conn.cursor()
-    cur.execute("SELECT session_id, user_id, context FROM sessions")
+    cur.execute("SELECT session_id, session_name, user_id, context FROM sessions")
     sessions = cur.fetchall()
     cur.close()
-    return [{"session_id": u[0], "user_id": u[1], "context": u[2]} for u in sessions]
+    return [{"session_id": u[0], "session_name": u[1], "user_id": u[2], "context": u[3]} for u in sessions]
 
 @router.post("/sessions")
 def post_session(session: dict):
     cursor = conn.cursor()
     cursor.execute(
-        "INSERT INTO sessions (user_id, context) VALUES (%s, %s) RETURNING session_id",
-        (session["user_id"], Json(session["context"]))
+        "INSERT INTO sessions (session_name, user_id, context) VALUES (%s, %s, %s) RETURNING session_id",
+        (session["session_name"], session["user_id"], Json(session["context"]))
     )
     session["session_id"] = cursor.fetchone()[0]
     conn.commit()
     cursor.close()
-    return {"session_id": session["session_id"], "context": Json(session["context"])}
+    return {"session_id": session["session_id"], "session_name": session["session_name"], "context": Json(session["context"])}

--- a/schema.sql
+++ b/schema.sql
@@ -9,6 +9,7 @@ CREATE TABLE IF NOT EXISTS users (
 
 CREATE TABLE IF NOT EXISTS sessions (
     session_id SERIAL PRIMARY KEY,
+    session_name VARCHAR(50) NOT NULL,
     user_id INT REFERENCES users(user_id) ON DELETE CASCADE,
     start_time TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     end_time TIMESTAMP,


### PR DESCRIPTION
Adding this attribute required changes on the schemas, and read/write logic on the database.

Related to #7 