### PR TITLE
[DEV 2.15] Enable option to UPDATE session names in DB

### DIFF
--- a/repositories/session_repo.py
+++ b/repositories/session_repo.py
@@ -23,3 +23,13 @@ def post_session(session: dict):
     conn.commit()
     cursor.close()
     return {"session_id": session["session_id"], "session_name": session["session_name"], "context": Json(session["context"])}
+
+@router.patch("/sessions/{session_id}")
+def patch_session(session_id: int, new_session_data: dict):
+    cursor = conn.cursor()
+    cursor.execute(
+        "UPDATE sessions SET session_name = %s WHERE session_id = %s", (new_session_data["new_session_name"], session_id)
+    )
+    conn.commit()
+    cursor.close()
+    return {"session_id": session_id, "session_name": new_session_data["new_session_name"]}


### PR DESCRIPTION
Added a PATCH endpoint that does an UPDATE on the `session_name` of a session matching the given `session_id` in the URI.

To test against the DB service directly:

```
curl -X PATCH "http://localhost:9000/sessions/87" \
     -H "Content-Type: application/json" \
     -d '
{"new_session_name":"NEW SESSION NAME"}'
```

And you will see the change reflected on that session on your `localhost:9000/sessions` response. 

Related to: #9 