### PR TITLE
[DEV 2.15] Add support for PATCHing sessions with new content

### DIFF
--- a/repositories/session_repo.py
+++ b/repositories/session_repo.py
@@ -36,21 +36,22 @@ def post_session(session: dict):
 @router.patch("/sessions/{session_id}")
 def patch_session(session_id: int, new_session_data: dict):
     cursor = conn.cursor()
+
+    response = {}
     if "new_session_name" in new_session_data:
         cursor.execute(
             "UPDATE sessions SET session_name = %s WHERE session_id = %s", (new_session_data["new_session_name"], session_id)
         )
-        conn.commit()
-        cursor.close()
-        return {"session_id": session_id, "session_name": new_session_data["new_session_name"]}
+        response = {"session_id": session_id, "session_name": new_session_data["new_session_name"]}
     elif "message" in new_session_data:
         context = json.dumps(new_session_data)
         cursor.execute(
             "UPDATE sessions SET context = %s WHERE session_id = %s", (context, session_id)
         )
-        conn.commit()
-        cursor.close()
-        return {"session_id": session_id, "context": context}
+        response = {"session_id": session_id, "context": context}
+    else:
+        response = {"DB ERROR: INVALID REQUEST"} # TODO implement error handling across these services
 
-    #in all other cases
-    return {"DB ERROR: INVALID REQUEST"} # TODO implement error handling across these services
+    conn.commit()
+    cursor.close()
+    return response

--- a/repositories/session_repo.py
+++ b/repositories/session_repo.py
@@ -1,16 +1,25 @@
 from fastapi import APIRouter
 from db_connection import conn
 from psycopg2.extras import Json
+import json
 
 router = APIRouter()
 
 @router.get("/sessions")
-def get_session():
+def get_sessions():
     cur = conn.cursor()
     cur.execute("SELECT session_id, session_name, user_id, context FROM sessions")
     sessions = cur.fetchall()
     cur.close()
     return [{"session_id": u[0], "session_name": u[1], "user_id": u[2], "context": u[3]} for u in sessions]
+
+@router.get("/sessions/{session_id}")
+def get_session(session_id: int):
+    cur = conn.cursor()
+    cur.execute("SELECT session_id, session_name, user_id, context FROM sessions WHERE session_id = %s", (session_id,))
+    session = cur.fetchone()
+    cur.close()
+    return {"session_id": session[0], "session_name": session[1], "user_id": session[2], "context": session[3]}
 
 @router.post("/sessions")
 def post_session(session: dict):
@@ -27,9 +36,21 @@ def post_session(session: dict):
 @router.patch("/sessions/{session_id}")
 def patch_session(session_id: int, new_session_data: dict):
     cursor = conn.cursor()
-    cursor.execute(
-        "UPDATE sessions SET session_name = %s WHERE session_id = %s", (new_session_data["new_session_name"], session_id)
-    )
-    conn.commit()
-    cursor.close()
-    return {"session_id": session_id, "session_name": new_session_data["new_session_name"]}
+    if "new_session_name" in new_session_data:
+        cursor.execute(
+            "UPDATE sessions SET session_name = %s WHERE session_id = %s", (new_session_data["new_session_name"], session_id)
+        )
+        conn.commit()
+        cursor.close()
+        return {"session_id": session_id, "session_name": new_session_data["new_session_name"]}
+    elif "message" in new_session_data:
+        context = json.dumps(new_session_data)
+        cursor.execute(
+            "UPDATE sessions SET context = %s WHERE session_id = %s", (context, session_id)
+        )
+        conn.commit()
+        cursor.close()
+        return {"session_id": session_id, "context": context}
+
+    #in all other cases
+    return {"DB ERROR: INVALID REQUEST"} # TODO implement error handling across these services


### PR DESCRIPTION
Under the PATCH endpoint handler, there are now two conditions:

1) the session is being renamed
2) the session's context is being updated

Depending on the key in the request payload, either of these conditions will be met.

Additionally, there is a new endpoint for GETting specific sessions using the `session_id` path arguments.

Fixes #7 